### PR TITLE
Fix carousel thumbnail image sizing consistency

### DIFF
--- a/src/lib/components/splide/splide-override.css
+++ b/src/lib/components/splide/splide-override.css
@@ -4,10 +4,16 @@
 
 .gallery--thumbs .splide__slide {
 	border-radius: 10px;
+	height: 100px;
+	overflow: hidden;
 }
 
 .gallery--thumbs .splide__slide img {
 	border-radius: 7px;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center;
 }
 
 .gallery--thumbs .splide__track--nav > .splide__list > .splide__slide.is-active {


### PR DESCRIPTION
## Summary

Fixes inconsistent carousel thumbnail heights by applying fixed dimensions and proper image scaling.

## Problem
The carousel thumbnail row on the homepage had inconsistent image heights because different blog images come in different aspect ratios. This caused some thumbnails to stretch vertically, some to have extra space, and overall visual inconsistency.

## Solution
Applied CSS fixes to ensure all thumbnails:
- Have a fixed height of 100px
- Use `object-fit: cover` to fill the space without distortion
- Use `object-position: center` to keep the image centered when cropped
- Have `overflow: hidden` on the slide container to prevent overflow

## Changes
- Updated `.gallery--thumbs .splide__slide` with fixed height and overflow hidden
- Updated `.gallery--thumbs .splide__slide img` with `object-fit: cover` and `object-position: center`

## Result
All carousel thumbnails now display at a consistent height with proper image scaling, providing a clean and professional appearance.